### PR TITLE
Fix bbkr maven in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ each Apple only has slight differences (while the core mechanics remain similar)
 
 ```groovy
 repositories {
-    maven { url "http://server.bbkr.space:8081/artifactory/libs-release" }
+    maven { url "http://server.bbkr.space/artifactory/libs-release" }
     maven { url 'https://jitpack.io' }
 }
 ```


### PR DESCRIPTION
`https://server.bbkr.space:8081/artifactory/libs-release` is dead, long live `https://server.bbkr.space/artifactory/libs-release` 🦀 